### PR TITLE
Fix git remote authentication for bump version workflow

### DIFF
--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -16,13 +16,16 @@ jobs:
         with:
           token: "${{ secrets.PERSONAL_ACCESS_TOKEN }}"
           fetch-depth: 0
+      - name: Configure Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin https://x-access-token:${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/${{ github.repository }}.git
       - name: Create bump and changelog
         uses: commitizen-tools/commitizen-action@master
         with:
           github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           changelog_increment_filename: body.md
-          git_name: "github-actions[bot]"
-          git_email: "github-actions[bot]@users.noreply.github.com"
         env:
           GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
       - name: Release


### PR DESCRIPTION
## Summary
Fixes the "Permission denied to aycandv" error in the bump version workflow by properly configuring git remote authentication.

## Root Cause
The commitizen action was trying to push using the personal username instead of the PERSONAL_ACCESS_TOKEN, causing permission errors.

## Solution
Added explicit git configuration step that:
- Sets git user as `github-actions[bot]`
- **Crucially**: Reconfigures the remote URL to use `x-access-token:$TOKEN@github.com` format

## Test plan
- [x] Added git remote configuration with proper token format
- [ ] Bump version workflow should now push successfully

🤖 Generated with [Claude Code](https://claude.ai/code)