### PR TITLE
Fix bump version workflow by disabling commitizen auto-push

### DIFF
--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -26,8 +26,14 @@ jobs:
         with:
           github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           changelog_increment_filename: body.md
+          push: false
+          commit: true
         env:
           GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+      - name: Push changes
+        run: |
+          git push origin master
+          git push origin --tags
       - name: Release
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
## Summary
Final fix for the "Permission denied to aycandv" error by preventing commitizen from auto-pushing and handling the push manually with proper authentication.

## Root Cause
The commitizen-action was overriding our git configuration and pushing with the original user credentials instead of the PERSONAL_ACCESS_TOKEN.

## Solution
- Set `push: false` in commitizen-action to prevent it from pushing
- Add manual push step that uses our properly configured git remote with token authentication
- This separates the commit creation from the push operation

## Changes
```yaml
- push: false     # Disable auto-push
- commit: true    # Still create commits and tags
```

Then manually push using the configured git remote.

## Test plan
- [x] Disable auto-push in commitizen action
- [x] Add manual push step with proper authentication  
- [ ] Bump version workflow should complete without permission errors

🤖 Generated with [Claude Code](https://claude.ai/code)