### PR TITLE
Final pipeline fixes - authentication and pandoc

### DIFF
--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -12,28 +12,18 @@ jobs:
     name: "Bump version and create changelog with commitizen"
     steps:
       - name: Check out
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: "${{ secrets.PERSONAL_ACCESS_TOKEN }}"
           fetch-depth: 0
-      - name: Configure Git
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git remote set-url origin https://x-access-token:${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/${{ github.repository }}.git
+          persist-credentials: true
       - name: Create bump and changelog
         uses: commitizen-tools/commitizen-action@master
         with:
           github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           changelog_increment_filename: body.md
-          push: false
-          commit: true
         env:
           GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-      - name: Push changes
-        run: |
-          git push origin master
-          git push origin --tags
       - name: Release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -22,6 +22,8 @@ jobs:
         with:
           github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           changelog_increment_filename: body.md
+          commit: true
+          push: true
         env:
           GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
       - name: Release

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,6 +13,10 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
+      - name: Install pandoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pandoc
       - run: pip install -r docs/requirements.txt
       - run: cd docs && make html
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
## Summary
Addresses the remaining pipeline failures with simplified solutions:

## Issues Fixed

### 1. Bump Version Authentication 
**Problem**: Complex git configuration wasn't working - still getting "Permission denied to aycandv"

**Solution**: 
- Simplified approach using `actions/checkout@v4` with `persist-credentials: true`
- Let GitHub Actions handle the authentication automatically
- Removed manual git configuration that was being overridden

### 2. Docs Build Missing Pandoc
**Problem**: `PandocMissing` error when building Sphinx docs with notebooks

**Solution**:
- Added pandoc installation step before building docs
- Required for nbsphinx to convert Jupyter notebooks to HTML

## Changes
- Simplified bump version workflow authentication 
- Added `sudo apt-get install pandoc` to docs workflow
- Upgraded to `actions/checkout@v4`

## Test plan
- [x] Simplified authentication using checkout persist-credentials
- [x] Added pandoc dependency for docs build
- [ ] Both workflows should now pass

🤖 Generated with [Claude Code](https://claude.ai/code)